### PR TITLE
feat[day1]: sum calibration values from an input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/input.txt

--- a/day1/entrypoint.ps1
+++ b/day1/entrypoint.ps1
@@ -1,0 +1,17 @@
+param (
+    [Parameter(Mandatory)]
+    [string]
+    $InputFilePath
+)
+
+Get-ChildItem './functions' `
+    | ForEach-Object { . $_ }
+
+$inputs = Get-Content -Path $InputFilePath
+
+$sum = 0
+foreach($line in $inputs){
+    $sum += Get-CalibrationValue $line
+}
+
+Write-Output "The sum of the calibration values: $sum"

--- a/day1/functions/Get-CalibrationValue.ps1
+++ b/day1/functions/Get-CalibrationValue.ps1
@@ -1,0 +1,70 @@
+function Get-FirstNumberInString {
+    [Cmdletbinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(ValueFromPipeline, Mandatory)]
+        [string]
+        $InputString
+    )
+
+    Write-Verbose "Getting first number in string: $InputString"
+    $result = $null
+
+    $i = 0
+    while($i -lt $InputString.Length){
+        $char = $InputString[$i]
+        if([int32]::TryParse($char, [ref]$result)){
+            Write-Verbose "Found a number: $char"
+            break
+        }
+        $i++
+    }
+
+    Write-Output "$result"
+}
+
+function Get-ReversedString {
+    [OutputType([string])]
+    param (
+        [Parameter(ValueFromPipeline, Mandatory)]
+        [string]
+        $InputString
+    )
+
+    Write-Verbose "Reversing string: $InputString"
+    $reversedInput = ''
+    $copiedInput = $InputString
+
+    while($reversedInput.Length -ne $InputString.Length){
+        $lastIndex = $copiedInput.Length - 1
+        $reversedInput += $copiedInput.Substring($lastIndex)
+        $copiedInput = $copiedInput.Substring(0, $lastIndex)
+    }
+
+    Write-Verbose "Reversed string: $reversedInput"
+    Write-Output $reversedInput
+}
+
+function Get-CalibrationValue {
+    [OutputType([int32])]
+    param (
+        [Parameter(Mandatory, Position=0)]
+        [string]
+        $CalibrationInput
+    )
+
+    Write-Verbose "Getting calibration value for input: $CalibrationInput"
+
+    $firstNumber = $CalibrationInput `
+        | Get-FirstNumberInString
+
+    $secondNumber = $CalibrationInput `
+        | Get-ReversedString `
+        | Get-FirstNumberInString
+
+    [int32]$result = [string]::Concat($firstNumber, $secondNumber)
+
+    Write-Verbose "Calibration value: $result"
+    return $result
+}
+


### PR DESCRIPTION
Given an input file of strings with letters and numbers, a powershell script to sum over the first and last number of each string, for each line in the input file. 

See more here: https://adventofcode.com/2023/day/1